### PR TITLE
Fixes example code in readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -22,7 +22,7 @@ var options = {
     name: "Project name"
 };
 
-var output = postcss(css)
+var output = postcss()
     .use(styleGuide(options))
     .process(css)
     .css;


### PR DESCRIPTION
Hi Masaaki,

I got an error to test the example code in readme. Here is the error log:
```
$ node index.js
/path/to/test/dir/node_modules/postcss/lib/lazy-result.js:194
            throw error;
                  ^
TypeError: string is not a function
    at LazyResult.run (/path/to/test/dir/node_modules/postcss/lib/lazy-result.js:191:24)
    at LazyResult.sync (/path/to/test/dir/node_modules/postcss/lib/lazy-result.js:177:32)
    at LazyResult.stringify (/path/to/test/dir/node_modules/postcss/lib/lazy-result.js:208:14)
    at LazyResult._createClass.get (/path/to/test/dir/node_modules/postcss/lib/lazy-result.js:230:25)
    at Object.<anonymous> (/path/to/test/dir/index.js:14:5)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
```

The argument required plugins functions in the postcss function implemented as API. In this case maybe it need not to provide css String and the others, just because you've already used `use()` API.

Thanks :sushi: