### PR TITLE
Grunt fails on psg-theme-default via grunt-postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "highlight.js": "^8.5.0",
     "marked": "^0.3.3",
     "mkdirp": "^0.5.1",
-    "postcss": "^5.0.2",
-    "psg-theme-default": "^0.4.0"
+    "postcss": "^5.0.2"
   },
   "devDependencies": {
+    "psg-theme-default": "^0.4.0",
     "tape": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Issue
When installing the plugin for use with Grunt via `$ npm install postcss-style-guide --save-dev` and adding it to a `Gruntfile.js` in accordance to the [grunt-postcss](https://github.com/nDmitry/grunt-postcss#usage) usage pattern, the build process fails at the `postcss-style-guide` task.

**Gruntfile.js**
```js
  grunt.initConfig({
      
      /* 
       * PostCSS: CSS Transformer via JS plugins
       * https://github.com/postcss/postcss
       */
      postcss: {
        options: {
          map: {
              inline: false,
              annotation: './'
          },
          
          /* 
           * PostCSS SCSS: SCSS parser for PostCSS
           * https://github.com/postcss/postcss-scss
           */
          parser: require('postcss-scss'),
          processors: [
            
            /* 
             * PreCSS: Sass-like markup
             * https://github.com/jonathantneal/precss
             */
            require('precss'),
            
            /* 
             * Autoprefixer: Add vendor prefixes using caniuse.com
             * https://github.com/postcss/autoprefixer
             */
            require('autoprefixer')({
                browsers: ['last 2 versions']
            }),
            
            /* 
             * CSS Nano: Modular minifier
             * https://github.com/ben-eb/cssnano
             */
            require('cssnano'),
            
            /* 
             * Style Guide: Generate a style guide automatically
             * https://github.com/morishitter/postcss-style-guide
             */
            require('postcss-style-guide')({
                theme: 'default',
                name: 'Project Name',
                dir: 'docs/css'
            })
          ]
        },
        dist: {
          src: 'scss/style.scss',
          dest: './style.css'
        }
      }
    ...
    });
```
**Terminal Error**
```shell
$ grunt serve
Loading "Gruntfile.js" tasks...ERROR
>> Error: ENOENT: no such file or directory, open '/Users/Username/project/node_modules/postcss-style-guide/node_modules/psg-theme-default/template.ejs'
Warning: Task "serve" not found. Use --force to continue.

Aborted due to warnings.
```

It looks like the issue is due to the flattening of dependencies when installing via NPM by default. If I go in to `node_modules/postcss-style-guide` and do a `$ npm install`, the project run's as expected.

## Expectation
After running `$ npm install postcss-style-guide --save-dev` and adding `postcss-style-guide` to my PostCSS Gruntfile configuration, I should be able to run my build process without issue since the dependent theme is being included with the style-guide.

## Resolution
Moving `psg-theme-default` to devDependencies so Grunt references module in expected location `node_modules/postcss-style-guide/node_modules/psg-theme-default` seems to do the trick. This change shouldn't impact your other settings.