### PR TITLE
Correctly resolve path to highlight.js github.css

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = postcss.plugin('postcss-style-guide', function (options) {
 })
 
 function generate (maps, options) {
-    var codeStylePath = path.join(__dirname, 'node_modules', 'highlight.js')
+    var codeStylePath = path.join(path.dirname(require.resolve('highlight.js')), '..')
     var codeStyle = fs.readFileSync(codeStylePath + '/styles/github.css', 'utf-8').trim()
 
     Promise.all([


### PR DESCRIPTION
Due to npm >3.x(?)'s flatter node_modules structure, this file wasn't resolved correctly. Using node's `require.resolve` to get actual file location.