### PR TITLE
Added processedCss to options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = postcss.plugin('postcss-style-guide', function (options) {
         })
 
         if (arguments[0] !== 'object') {
-            processedCSS = root.toString().trim()
+            options.processedCSS = root.toString().trim()
         }
 
         generate(maps, options)


### PR DESCRIPTION
processedCSS was not being added to options object. Cause the processed css from custom stylesheets to not be added to the generated styleguide.