### PR TITLE
Add `silent` option to prevent `success`-messages from being outputted

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,11 @@ module.exports = postcss.plugin('postcss-style-guide', function (opts) {
                 colorPalette: palette
             });
             fileWriter.write(params.dest, html);
-            console.log('Successfully created style guide!');
+
+            if (!opts.silent) {
+                console.log('Successfully created style guide!');
+            }
+
             return root;
           }).catch(function (err) {
             console.error('generate err:', err);

--- a/test/index.js
+++ b/test/index.js
@@ -153,7 +153,8 @@ test('integration test: exist output', function (t) {
     var opts = {
         name: 'Default theme',
         src: 'test/input.css',
-        dest: 'test/dest/exist/index.html'
+        dest: 'test/dest/exist/index.html',
+        silent: true
     };
     var cwd = process.cwd();
     var src = path.resolve(cwd, 'test/input.css');


### PR DESCRIPTION
We're using this as part of a build process, and the fact that it generates a `success` message is kind of noisy when it is applied to many input files.

I've added a simple `silent` option to prevent any output in case of successful builds.
