### PR TITLE
Fixed error on line returns in Window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 styleguide
+.vscode/

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -25,8 +25,8 @@ exports.analyze = function (root) {
             rule = rule.next();
         }
         var joined = rules.join('\n\n');
-        var md = comment.text.replace(/(@document|@doc|@docs|@styleguide)\s*\n/, '');
-        md = md.replace(/@title\s.*\n/, '');
+        var md = comment.text.replace(/(@document|@doc|@docs|@styleguide)\s*[\r]*\n/, '');
+        md = md.replace(/@title\s.*[\r]*\n/, '');
         list.push({
             rule: this.syntaxHighlighter.highlight(joined),
             html: this.markdownParser(md),


### PR DESCRIPTION
When working with certain tools in Windows, module didn't get the \r\n for new lines and would eventually not replace "@title", printing it in the output HTML 