### PR TITLE
Multi-file and meta improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var postcss = require('postcss');
 
 var analyzer = require('./lib/analyzer');
@@ -18,7 +19,7 @@ module.exports = postcss.plugin('postcss-style-guide', function (opts) {
         } catch (err) {
             throw err;
         }
-        var maps = analyzer.analyze(root);
+        var maps = analyzer.analyze(root, opts);
         var palette = colorPalette.parse(root.toString());
         var promise = syntaxHighlighter.execute({
             src: params.src,
@@ -34,7 +35,7 @@ module.exports = postcss.plugin('postcss-style-guide', function (opts) {
             fileWriter.write(params.dest, html);
 
             if (!opts.silent) {
-                console.log('Successfully created style guide!');
+                console.log('Successfully created style guide at ' + path.relative(process.cwd(), params.dest) + '!');
             }
 
             return root;

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -5,7 +5,7 @@ exports.setModules = function (syntaxHighlighter, markdownParser) {
   this.markdownParser = markdownParser;
 }
 
-exports.analyze = function (root) {
+exports.analyze = function (root, opts) {
     var list = [];
     var linkId = 0;
     root.walkComments(function (comment) {
@@ -26,12 +26,16 @@ exports.analyze = function (root) {
         }
         var joined = rules.join('\n\n');
         var md = comment.text.replace(/(@document|@doc|@docs|@styleguide)\s*\n/, '');
+        md = md.replace(new RegExp('@(' + Object.keys(meta).join('|') + ')\\s.*\\n', 'g'), '');
+
         md = md.replace(/@title\s.*\n/, '');
+
         list.push({
+            meta: meta,
             rule: this.syntaxHighlighter.highlight(joined),
             html: this.markdownParser(md),
             link: {
-                id: 'psg-link-' + linkId,
+                id: (meta.id || 'psg-link-' + linkId),
                 title: meta.title || null
             }
         });

--- a/lib/params.js
+++ b/lib/params.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var result = require('./utils').result;
 
 module.exports = function (root, opts, pluginOpts) {
     var params = {};
@@ -13,7 +14,7 @@ module.exports = function (root, opts, pluginOpts) {
     }
 
     if (opts.dest) {
-        params.dest = path.resolve(cwd, opts.dest);
+        params.dest = path.resolve(cwd, result(opts.dest, opts, pluginOpts));
     } else {
         var from = (pluginOpts || {}).from; // for the gulp and grunt
         var output = from ? path.basename(from, '.css') : 'index.html'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,15 @@
+var ObjProto = Object.prototype;
+var toString = ObjProto.toString;
+
+function isFunction(value) {
+    return toString.call(value) === '[object Function]';
+}
+module.exports.isFunction = isFunction;
+
+function result(obj) {
+    if (isFunction(obj)) {
+        return obj.apply(null, [].slice.call(arguments, 1));
+    }
+    return obj;
+}
+module.exports.result = result;

--- a/test/index.js
+++ b/test/index.js
@@ -114,6 +114,7 @@ test('analyzer: analyze root node', function (t) {
     var actual = analyzer.analyze(root);
 
     var expected = [{
+        meta: { styleguide: true, title: 'input sample', mymeta: 'test' },
         rule: '<span class="hljs-class">.class</span> <span class="hljs-rules">{\n  <span class="hljs-rule"><span class="hljs-attribute">color</span>:<span class="hljs-value"> blue</span></span>;\n}</span>',
         html: '<h1 id="h1">h1</h1>',
         link: {
@@ -122,6 +123,7 @@ test('analyzer: analyze root node', function (t) {
         }
     },
     {
+        meta: { doc: true },
         rule: '<span class="hljs-class">.class</span> <span class="hljs-rules">{\n  <span class="hljs-rule"><span class="hljs-attribute">color</span>:<span class="hljs-value"> red</span></span>;\n}</span>',
         html: '<h2 id="h2">h2</h2>',
         link: {

--- a/test/input.css
+++ b/test/input.css
@@ -2,6 +2,7 @@
 @styleguide
 
 @title input sample
+@mymeta test
 
 # h1
 */


### PR DESCRIPTION
Hi,

I love this plugin, so I added a couple more features and updated tests:

### `dest` as function

`dest` param can be a function accepting `opts` and `pluginOpts` params. This allows gulp users to generate mutliple styleguides from each file in the stream:

```js
dest(opts, pluginOpts) {
    if (pluginOpts.from) {
        const filename = path.basename(pluginOpts.from, '.css');
        return `styleguides/${filename}.html`;
    }
    return 'styleguides/index.html'
}
```

### Allow custom meta

All parsed meta are stored in a new `meta` property in every `map` object. Also if there's a `@id` meta it will be used as `meta.link.id` value.

In the markdown source metas are removed.